### PR TITLE
Add Laravel 13 compatibility constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Laravel package for sending physical postcards through the Swiss Post Postcard
 ## Requirements
 
 -   PHP 8.3 or higher
--   Laravel 10.0, 11.0, or 12.0
+-   Laravel 10.0, 11.0, 12.0, or 13.0
 -   Swiss Post Postcard API credentials (obtained through contract with Swiss Post)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "saloonphp/saloon": "^4.0",
         "spatie/laravel-package-tools": "^1.16"
     },
@@ -26,7 +26,7 @@
         "larastan/larastan": "^2.9||^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.6",
+        "orchestra/testbench": "^10.6||^11.0",
         "pestphp/pest": "^2.0||^3.0||^4.0",
         "pestphp/pest-plugin-arch": "^2.5||^3.0||^4.0",
         "pestphp/pest-plugin-laravel": "^2.0||^3.0||^4.0",

--- a/demo-app/composer.json
+++ b/demo-app/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "laravel/framework": "^12.0",
+    "laravel/framework": "^12.0||^13.0",
     "laravel/tinker": "^2.10.1",
     "gigerit/laravel-swiss-post-postcard-api-client": "dev-main"
   },


### PR DESCRIPTION
### Motivation
- Allow the package and demo app to be used with Laravel 13 by expanding dependency constraints and documentation.

### Description
- Updated `composer.json` to include `^13.0` for `illuminate/contracts` and allow `orchestra/testbench` `^11.0`, updated `demo-app/composer.json` to accept `laravel/framework` `^13.0`, and updated `README.md` to list Laravel 13 support.

### Testing
- Ran `composer validate --no-check-publish` at the repository root which passed (with a non-blocking `version` field warning). 
- Ran `composer validate --no-check-publish` in `demo-app` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e770f2ad388325b3011a8bae70b6e7)